### PR TITLE
Fix dataframe creation from dic.items()

### DIFF
--- a/pca/pca.py
+++ b/pca/pca.py
@@ -335,7 +335,7 @@ class pca():
         PC_weak = ['PC{}'.format(i + 1) for i in idxrow]
 
         # build the dataframe
-        topfeat = pd.DataFrame(dic.items(), columns=['PC', 'feature'])
+        topfeat = pd.DataFrame(list(dic.items()), columns=['PC', 'feature'])
         topfeat['loading'] = loading_best
         topfeat['type'] = 'best'
         # Weak features


### PR DESCRIPTION
On newer versions of Python, `dict.items` returns a `dict_items` that some versions of pandas cannot use to construct a `DataFrame`, raising an exception.

This fixes this issue by forcing the construction of a `list` from the dictionary's `(key, value)` pairs contained in the `dict_items` object.