### PR TITLE
Minor: Fix parameter description

### DIFF
--- a/pca/pca.py
+++ b/pca/pca.py
@@ -32,7 +32,7 @@ class pca:
     Parameters
     ----------
     n_components : [0..1] or [1..number of samples-1], (default: 0.95)
-        Number of PCs to be returned. When n_components is set >0, the specified number of PCs is returned.
+        Number of PCs to be returned. When n_components is set >=1, the specified number of PCs is returned.
         When n_components is set between [0..1], the number of PCs is returned that covers at least this percentage of variance.
         n_components=None : Return all PCs
         n_components=0.95 : Return the number of PCs that cover at least 95% of variance.


### PR DESCRIPTION
Just a small change: the description for the `n_components` parameter is slightly incorrect in the range for which a specific number of PCs are used.  The original description states that this beings after 0, however that is actually covered by the next case (percentage of variance).  It isn't until the value becomes 1 that it describes how many PCs should be returned.

This behavior is controlled by [this branch](https://github.com/erdogant/pca/blob/53d8f8eb9111e44e2d2f2d70b1a478a167abfa43/pca/pca.py#L283)